### PR TITLE
fix: replace internal cluster URLs with external authentik.local address for SSO

### DIFF
--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -108,6 +108,6 @@ database:
 # Authentik OIDC configuration
 authentik:
   enabled: false
-  url: "http://authentik.admin-apps.svc.cluster.local:9000"
+  url: "http://authentik.local"
   clientId: "wordpress"
   clientSecret: "" # This should be populated from a secret

--- a/terraform/platform/main.tf
+++ b/terraform/platform/main.tf
@@ -334,7 +334,7 @@ resource "kubernetes_secret" "wordpress_oauth_env" {
   }
   data = {
     WORDPRESS_ENCRYPTION_KEY = random_password.wordpress_encryption_key.result
-    AUTHENTIK_URL           = "http://authentik.admin-apps.svc.cluster.local"
+    AUTHENTIK_URL           = "http://authentik.local"
     AUTHENTIK_CLIENT_ID     = var.authentik_client_id
     AUTHENTIK_CLIENT_SECRET = var.authentik_client_secret
   }

--- a/terraform/tenant/main.tf
+++ b/terraform/tenant/main.tf
@@ -210,7 +210,7 @@ resource "helm_release" "wordpress" {
       }
       authentik = {
         enabled = true
-        url = "http://authentik.admin-apps.svc.cluster.local:9000"
+        url = "http://authentik.local"
         clientId = "wordpress-${each.key}"
         clientSecret = "a-secure-secret" # This should be a secret
       }

--- a/terraform/tenant/variables.tf
+++ b/terraform/tenant/variables.tf
@@ -214,7 +214,7 @@ variable "tenant_management" {
 # Authentik OAuth2 configuration
 variable "authentik_config" {
   type = object({
-    server_url    = optional(string, "http://authentik.admin-apps.svc.cluster.local:9000")
+    server_url    = optional(string, "http://authentik.local")
     admin_token   = optional(string, "")
     auto_create_apps = optional(bool, true)
   })


### PR DESCRIPTION
Fixes #5

## Summary
- Replace authentik.admin-apps.svc.cluster.local with authentik.local in all configuration files
- Fix SSO redirect issue that was sending users to internal cluster address
- Update platform, tenant, and WordPress chart configurations

## Test Plan
- [ ] Apply Terraform changes to cluster
- [ ] Test SSO login flow from external browser
- [ ] Verify Authentik redirects work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)